### PR TITLE
feat: Enhance AI commit generation with contextual inputs

### DIFF
--- a/auto_commit_ai/core.py
+++ b/auto_commit_ai/core.py
@@ -188,6 +188,9 @@ class AutoCommitAI:
         provider_name: Optional[str] = None,
         include_all: bool = False,
         language: Optional[str] = None,
+        branch_name: Optional[bool] = False,
+        previous_commits: Optional[bool] = False,
+        additional_context: Optional[str] = None,
         show_status: bool = True,
     ) -> Dict[str, Any]:
         """
@@ -233,8 +236,20 @@ class AutoCommitAI:
                 f"🤖 Generating commit message with {ai_provider.__class__.__name__}..."
             )
             try:
+                if branch_name:
+                    branch_name = self.git_utils.get_branch_name()
+                else:
+                    branch_name = None
+                if previous_commits:
+                    previous_commits = self.git_utils.get_commit_history(max_count=5)
+                else:
+                    previous_commits = None
                 commit_message = ai_provider.generate_commit_message(
-                    diff_content, language
+                    diff_content,
+                    language,
+                    branch_name,
+                    previous_commits,
+                    additional_context,
                 )
             except Exception as e:
                 error_msg = f"Error generating commit message: {e}"
@@ -283,6 +298,9 @@ class AutoCommitAI:
         provider_name: Optional[str] = None,
         include_all: bool = False,
         language: Optional[str] = None,
+        branch_name: Optional[bool] = False,
+        previous_commits: Optional[bool] = False,
+        additional_context: Optional[str] = None,
     ) -> Optional[Dict[str, str]]:
         """
         Generate and preview a commit message without committing.
@@ -307,7 +325,21 @@ class AutoCommitAI:
             print(
                 f"🤖 Generating commit message preview with {ai_provider.__class__.__name__}..."
             )
-            commit_message = ai_provider.generate_commit_message(diff_content, language)
+            if branch_name:
+                branch_name = self.git_utils.get_branch_name()
+            else:
+                branch_name = None
+            if previous_commits:
+                previous_commits = self.git_utils.get_commit_history(max_count=5)
+            else:
+                previous_commits = None
+            commit_message = ai_provider.generate_commit_message(
+                diff_content,
+                language,
+                branch_name,
+                previous_commits,
+                additional_context,
+            )
 
             # Display message
             self._display_commit_message(commit_message)

--- a/auto_commit_ai/git_utils.py
+++ b/auto_commit_ai/git_utils.py
@@ -99,6 +99,13 @@ class GitUtils:
         except Exception as e:
             raise Exception(f"Error getting repository status: {e}")
 
+    def get_branch_name(self) -> str:
+        """Gets the current branch name."""
+        try:
+            return self.repo.active_branch.name
+        except Exception as e:
+            raise Exception(f"Error getting current branch name: {e}")
+
     def stage_all_changes(self):
         """Adds all changes to the staging area."""
         try:

--- a/auto_commit_ai/providers/azure.py
+++ b/auto_commit_ai/providers/azure.py
@@ -30,11 +30,18 @@ class AzureOpenAIProvider(AIProvider):
         return bool(self.config.azure_api_key and self.config.azure_endpoint)
 
     def generate_commit_message(
-        self, diff_content: str, language: Optional[str] = None
+        self,
+        diff_content: str,
+        language: Optional[str] = None,
+        branch_name: Optional[str] = None,
+        previous_commits: Optional[str] = None,
+        additional_context: Optional[str] = None,
     ) -> str:
         """Generate a commit message using Azure OpenAI."""
         language = language or self.config.default_lang or "en"
-        prompt = self._create_base_prompt(diff_content, language)
+        prompt = self._create_base_prompt(
+            diff_content, language, branch_name, previous_commits, additional_context
+        )
 
         max_attempts = 3
         attemps = 0

--- a/auto_commit_ai/providers/google.py
+++ b/auto_commit_ai/providers/google.py
@@ -27,7 +27,12 @@ class GoogleProvider(AIProvider):
         return bool(self.config.google_api_key)
 
     def generate_commit_message(
-        self, diff_content: str, language: Optional[str] = None
+        self,
+        diff_content: str,
+        language: Optional[str] = None,
+        branch_name: Optional[str] = None,
+        previous_commits: Optional[str] = None,
+        additional_context: Optional[str] = None,
     ) -> str:
         """Generate a commit message using Google Gemini."""
         language = language or self.config.default_lang or "en"
@@ -35,9 +40,14 @@ class GoogleProvider(AIProvider):
         prompt = (
             self.prompts.SYSTEM_PROMPT
             + "\n\n"
-            + self._create_base_prompt(diff_content, language)
+            + self._create_base_prompt(
+                diff_content,
+                language,
+                branch_name,
+                previous_commits,
+                additional_context,
+            )
         )
-
         max_attempts = 3
         attemps = 0
         while attemps < max_attempts:

--- a/auto_commit_ai/providers/ollama.py
+++ b/auto_commit_ai/providers/ollama.py
@@ -26,11 +26,18 @@ class OllamaProvider(AIProvider):
         return bool(self.config.ollama_model)
 
     def generate_commit_message(
-        self, diff_content: str, language: Optional[str] = None
+        self,
+        diff_content: str,
+        language: Optional[str] = None,
+        branch_name: Optional[str] = None,
+        previous_commits: Optional[str] = None,
+        additional_context: Optional[str] = None,
     ) -> str:
         """Generate a commit message using Ollama."""
         language = language or self.config.default_lang or "en"
-        prompt = self._create_base_prompt(diff_content, language)
+        prompt = self._create_base_prompt(
+            diff_content, language, branch_name, previous_commits, additional_context
+        )
 
         max_attempts = 3
         attemps = 0

--- a/auto_commit_ai/providers/openai.py
+++ b/auto_commit_ai/providers/openai.py
@@ -28,11 +28,18 @@ class OpenAIProvider(AIProvider):
         return bool(self.config.openai_api_key)
 
     def generate_commit_message(
-        self, diff_content: str, language: Optional[str] = None
+        self,
+        diff_content: str,
+        language: Optional[str] = None,
+        branch_name: Optional[str] = None,
+        previous_commits: Optional[str] = None,
+        additional_context: Optional[str] = None,
     ) -> str:
         """Generate a commit message using OpenAI."""
         language = language or self.config.default_lang or "en"
-        prompt = self._create_base_prompt(diff_content, language)
+        prompt = self._create_base_prompt(
+            diff_content, language, branch_name, previous_commits, additional_context
+        )
 
         max_attempts = 3
         attemps = 0

--- a/auto_commit_ai/providers/prompts.py
+++ b/auto_commit_ai/providers/prompts.py
@@ -1,30 +1,66 @@
-# System prompts
-SYSTEM_PROMPT = """You are an expert in Git who creates concise and descriptive commit titles and descriptions following best practices."""
+SYSTEM_PROMPT = """You are an expert in Git who creates concise and descriptive commit titles and descriptions following 
+best practices."""
 
 BASE_COMMIT_PROMPT = """
-Based on the following code changes, generate a concise and descriptive commit title and description.
+Based on the following code changes, generate a concise and descriptive commit title and description. Adittionally, there are 
+some extra information can be added:
+- Branch name: to help you understand the general context of the changes. Usually is the name of an issue (not use only for 
+the title, just use the name or key words to understand all the changes and know what is the purpose or objective of them)
+- Previous commits: as branch name, it's only to have related changes made before, but you must to use the current changes mainly
+- Additional context: specify requirements, objectives or extra info in case that it's not easy to extract only with the code
 
 Requirements:
 - Follow the Conventional Commits format.
 - The message must be written in {language} (ISO 639-1).
-- If there are multiple relevant changes (i.e., those that affect functionality such as bug fixes, features, or significant refactors), condense them into the title.
+- If there are multiple relevant changes (i.e., those that affect functionality such as bug fixes, features, or significant 
+refactors), condense them into the title.
 - If there's only one relevant change, use it as the title and provide a detailed description.
 - Ignore irrelevant changes like formatting, whitespace, or comments.
+- You must focus on the main changes and their purpose, not on the implementation details or minor changes (unless there are only minor changes).
 
 Output instructions:
 - Respond **only** with a JSON object containing exactly two keys: "title" and "description".
 - Do **not** include any other text, explanation, or formatting outside of the JSON object.
 - The response **must** be a valid JSON object. No markdown formatting. No introductory or closing remarks.
 
+Return only the JSON object.
+
+Following are all the information you have about the changes:
+
+"""
+
+BRANCH_NAME = """
+
+Branch name:
+{branch_name}
+
+"""
+
+PREVIOUS_COMMITS = """
+
+Previous commits:
+{previous_commits}
+
+"""
+
+ADDITIONAL_CONTEXT = """
+
+Additional context:
+{additional_context}
+
+"""
+
+CODE_CHANGES = """
+
 Code changes:
 {diff_content}
-
-Return only the JSON object.
 
 """
 
 RESPONSE_JSON_EXAMPLE = """
+
 RESPONSE JSON EXAMPLE:
+
 ```json
 {
     "title": "feat: add new feature",

--- a/custom_prompts_example.py
+++ b/custom_prompts_example.py
@@ -1,30 +1,66 @@
-# System prompts
-SYSTEM_PROMPT = """You are an expert in Git who creates concise and descriptive commit titles and descriptions following best practices."""
+SYSTEM_PROMPT = """You are an expert in Git who creates concise and descriptive commit titles and descriptions following 
+best practices."""
 
 BASE_COMMIT_PROMPT = """
-Based on the following code changes, generate a concise and descriptive commit title and description.
+Based on the following code changes, generate a concise and descriptive commit title and description. Adittionally, there are 
+some extra information can be added:
+- Branch name: to help you understand the general context of the changes. Usually is the name of an issue (not use only for 
+the title, just use the name or key words to understand all the changes and know what is the purpose or objective of them)
+- Previous commits: as branch name, it's only to have related changes made before, but you must to use the current changes mainly
+- Additional context: specify requirements, objectives or extra info in case that it's not easy to extract only with the code
 
 Requirements:
 - Follow the Conventional Commits format.
 - The message must be written in {language} (ISO 639-1).
-- If there are multiple relevant changes (i.e., those that affect functionality such as bug fixes, features, or significant refactors), condense them into the title.
+- If there are multiple relevant changes (i.e., those that affect functionality such as bug fixes, features, or significant 
+refactors), condense them into the title.
 - If there's only one relevant change, use it as the title and provide a detailed description.
 - Ignore irrelevant changes like formatting, whitespace, or comments.
+- You must focus on the main changes and their purpose, not on the implementation details or minor changes (unless there are only minor changes).
 
 Output instructions:
 - Respond **only** with a JSON object containing exactly two keys: "title" and "description".
 - Do **not** include any other text, explanation, or formatting outside of the JSON object.
 - The response **must** be a valid JSON object. No markdown formatting. No introductory or closing remarks.
 
+Return only the JSON object.
+
+Following are all the information you have about the changes:
+
+"""
+
+BRANCH_NAME = """
+
+Branch name:
+{branch_name}
+
+"""
+
+PREVIOUS_COMMITS = """
+
+Previous commits:
+{previous_commits}
+
+"""
+
+ADDITIONAL_CONTEXT = """
+
+Additional context:
+{additional_context}
+
+"""
+
+CODE_CHANGES = """
+
 Code changes:
 {diff_content}
-
-Return only the JSON object.
 
 """
 
 RESPONSE_JSON_EXAMPLE = """
+
 RESPONSE JSON EXAMPLE:
+
 ```json
 {
     "title": "feat: add new feature",


### PR DESCRIPTION
This commit introduces new command-line interface (CLI) options to provide additional context to the AI model when generating commit messages.

- `--branch-name (-bn)`: Includes the current Git branch name as context.
- `--previous-commits (-pc)`: Includes the last 5 commit messages as context. *Note: This feature is experimental.*
- `--additional-context (-ac)`: Allows users to provide arbitrary extra text as context.

To support these new features, the prompt generation logic has been refactored to dynamically incorporate these contextual inputs. The `AutoCommitAI` class and all AI provider implementations have been updated accordingly.

Additionally, the `--branches` CLI option and its associated functionality for displaying branch information have been removed.